### PR TITLE
Block Spoofers

### DIFF
--- a/packages/contracts/test/ERC20Test.t.sol
+++ b/packages/contracts/test/ERC20Test.t.sol
@@ -71,7 +71,6 @@ contract ERC20Test is MudTest {
 
   function testPlace() public {
     testMint();
-    vm.startPrank(alice);
     uint256 x = 49;
     uint256 y = 50;
     world.place20(amount, x, y);

--- a/packages/mudtokens/package.json
+++ b/packages/mudtokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mudtokens",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Integration for tokens into the MUD architecture",
   "main": "index.js",
   "scripts": {

--- a/packages/mudtokens/src/erc1155/ERC1155Proxy.sol
+++ b/packages/mudtokens/src/erc1155/ERC1155Proxy.sol
@@ -10,7 +10,7 @@ import { SystemRegistry } from "@latticexyz/world/src/modules/core/tables/System
 import { LibERC1155 } from "./LibERC1155.sol";
 
 contract ERC1155Proxy is IERC1155 {
-  IBaseWorld private world;
+  IBaseWorld public immutable world;
   bytes16 private immutable namespace;
 
   constructor(IBaseWorld _world, bytes16 _namespace) {

--- a/packages/mudtokens/src/erc1155/LibERC1155.sol
+++ b/packages/mudtokens/src/erc1155/LibERC1155.sol
@@ -6,12 +6,19 @@ import { IERC1155 } from "./interfaces/IERC1155.sol";
 import { ERC1155Proxy } from "./ERC1155Proxy.sol";
 import { IERC1155Receiver } from "./interfaces/IERC1155Receiver.sol";
 import { IERC1155MetadataURI } from "./interfaces/IERC1155MetadataURI.sol";
+import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 import {ERC1155ApprovalTable as Approvals, ERC1155BalanceTable as Balance, ERC1155MetadataTable as Metadata} from "../codegen/Tables.sol";
 import { ERC1155_APPROVAL_T as APPROVALS, ERC1155_BALANCE_T as BALANCE, ERC1155_METADATA_T as METADATA } from "../common/constants.sol";
 import { ResourceSelector, ROOT_NAMESPACE } from "@latticexyz/world/src/ResourceSelector.sol";
 
 library LibERC1155 {
+  modifier onlyProxyWorld(bytes16 namespace) {
+    ERC1155Proxy _proxy = ERC1155Proxy(proxy(namespace));
+    require(address(_proxy.world()) == StoreSwitch.getStoreAddress(), "ERC20: invalid world");
+    _;
+  }
+
   function getSelector(bytes16 namespace, bytes16 _name) private pure returns (bytes32) {
     return ResourceSelector.from(namespace, _name);
   }
@@ -580,7 +587,7 @@ library LibERC1155 {
     address to,
     uint256 id,
     uint256 value
-  ) internal {
+  ) internal onlyProxyWorld(namespace){
     ERC1155Proxy(proxy(namespace)).emitTransferSingle(operator, from, to, id, value);
   }
 
@@ -591,11 +598,11 @@ library LibERC1155 {
     address to,
     uint256[] memory ids,
     uint256[] memory values
-  ) internal {
+  ) internal onlyProxyWorld(namespace){
     ERC1155Proxy(proxy(namespace)).emitTransferBatch(operator, from, to, ids, values);
   }
 
-  function emitApprovalForAll(bytes16 namespace, address account, address operator, bool approved) internal {
+  function emitApprovalForAll(bytes16 namespace, address account, address operator, bool approved) internal onlyProxyWorld(namespace){
     ERC1155Proxy(proxy(namespace)).emitApprovalForAll(account, operator, approved);
   }
 
@@ -1211,24 +1218,22 @@ library LibERC1155 {
   }
 
   function emitTransferSingle(
-    
     address operator,
     address from,
     address to,
     uint256 id,
     uint256 value
-  ) internal {
+  ) internal onlyProxyWorld(ROOT_NAMESPACE){
     ERC1155Proxy(proxy(ROOT_NAMESPACE)).emitTransferSingle(operator, from, to, id, value);
   }
 
   function emitTransferBatch(
-    
     address operator,
     address from,
     address to,
     uint256[] memory ids,
     uint256[] memory values
-  ) internal {
+  ) internal onlyProxyWorld(ROOT_NAMESPACE){
     ERC1155Proxy(proxy(ROOT_NAMESPACE)).emitTransferBatch(operator, from, to, ids, values);
   }
 

--- a/packages/mudtokens/src/erc1155/LibERC1155.sol
+++ b/packages/mudtokens/src/erc1155/LibERC1155.sol
@@ -15,7 +15,7 @@ import { ResourceSelector, ROOT_NAMESPACE } from "@latticexyz/world/src/Resource
 library LibERC1155 {
   modifier onlyProxyWorld(bytes16 namespace) {
     ERC1155Proxy _proxy = ERC1155Proxy(proxy(namespace));
-    require(address(_proxy.world()) == StoreSwitch.getStoreAddress(), "ERC20: invalid world");
+    require(address(_proxy.world()) == StoreSwitch.getStoreAddress(), "ERC1155: invalid world");
     _;
   }
 

--- a/packages/mudtokens/src/erc20/ERC20Proxy.sol
+++ b/packages/mudtokens/src/erc20/ERC20Proxy.sol
@@ -12,7 +12,7 @@ import { SystemRegistry } from "@latticexyz/world/src/modules/core/tables/System
 import { LibERC20 } from "./LibERC20.sol";
 
 contract ERC20Proxy is IERC20, IERC20Metadata {
-  IBaseWorld private world;
+  IBaseWorld public immutable world;
   bytes16 private immutable namespace;
 
   constructor(IBaseWorld _world, bytes16 _namespace) {

--- a/packages/mudtokens/src/erc20/LibERC20.sol
+++ b/packages/mudtokens/src/erc20/LibERC20.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0;
 
 import { IBaseWorld } from "@latticexyz/world/src/interfaces/IBaseWorld.sol";
 import { ResourceSelector, ROOT_NAMESPACE } from "@latticexyz/world/src/ResourceSelector.sol";
+import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 import { AllowanceTable, BalanceTable, MetadataTable } from "../codegen/Tables.sol";
 import { ERC20_ALLOWANCE_T as ALLOWANCE, ERC20_BALANCE_T as BALANCE, ERC20_METADATA_T as METADATA } from "../common/constants.sol";
 import { IERC20 } from "./interfaces/IERC20.sol";
@@ -10,6 +11,12 @@ import { IERC20Metadata } from "./interfaces/IERC20Metadata.sol";
 import { ERC20Proxy } from "./ERC20Proxy.sol";
 
 library LibERC20 {
+  modifier onlyProxyWorld(bytes16 namespace) {
+    ERC20Proxy _proxy = ERC20Proxy(proxy(namespace));
+    require(address(_proxy.world()) == StoreSwitch.getStoreAddress(), "ERC20: invalid world");
+    _;
+  }
+
   function from(bytes16 namespace, bytes16 _name) private pure returns (bytes32) {
     return ResourceSelector.from(namespace, _name);
   }
@@ -282,19 +289,19 @@ library LibERC20 {
     }
   }
 
-  function emitTransfer(bytes16 namespace, address _from, address to, uint256 amount) internal {
+  function emitTransfer(bytes16 namespace, address _from, address to, uint256 amount) internal onlyProxyWorld(namespace){
     ERC20Proxy(proxy(namespace)).emitTransfer(_from, to, amount);
   }
 
-  function emitTransfer(IBaseWorld world, bytes16 namespace, address _from, address to, uint256 amount) internal {
+  function emitTransfer(IBaseWorld world, bytes16 namespace, address _from, address to, uint256 amount) internal onlyProxyWorld(namespace) {
     ERC20Proxy(proxy(world, namespace)).emitTransfer(_from, to, amount);
   }
 
-  function emitApproval(bytes16 namespace, address _from, address to, uint256 amount) internal {
+  function emitApproval(bytes16 namespace, address _from, address to, uint256 amount) internal onlyProxyWorld(namespace){
     ERC20Proxy(proxy(namespace)).emitApproval(_from, to, amount);
   }
 
-  function emitApproval(IBaseWorld world, bytes16 namespace, address _from, address to, uint256 amount) internal {
+  function emitApproval(IBaseWorld world, bytes16 namespace, address _from, address to, uint256 amount) internal onlyProxyWorld(namespace){
     ERC20Proxy(proxy(world, namespace)).emitApproval(_from, to, amount);
   }
 
@@ -553,19 +560,19 @@ library LibERC20 {
     }
   }
 
-  function emitTransfer(address _from, address to, uint256 amount) internal {
+  function emitTransfer(address _from, address to, uint256 amount) internal onlyProxyWorld(ROOT_NAMESPACE){
     ERC20Proxy(proxy(ROOT_NAMESPACE)).emitTransfer(_from, to, amount);
   }
 
-  function emitTransfer(IBaseWorld world, address _from, address to, uint256 amount) internal {
+  function emitTransfer(IBaseWorld world, address _from, address to, uint256 amount) internal onlyProxyWorld(ROOT_NAMESPACE){
     ERC20Proxy(proxy(world, ROOT_NAMESPACE)).emitTransfer(_from, to, amount);
   }
 
-  function emitApproval(address _from, address to, uint256 amount) internal {
+  function emitApproval(address _from, address to, uint256 amount) internal onlyProxyWorld(ROOT_NAMESPACE){
     ERC20Proxy(proxy(ROOT_NAMESPACE)).emitApproval(_from, to, amount);
   }
 
-  function emitApproval(IBaseWorld world, address _from, address to, uint256 amount) internal {
+  function emitApproval(IBaseWorld world, address _from, address to, uint256 amount) internal onlyProxyWorld(ROOT_NAMESPACE){
     ERC20Proxy(proxy(world, ROOT_NAMESPACE)).emitApproval(_from, to, amount);
   }
 }

--- a/packages/mudtokens/src/erc721/ERC721Proxy.sol
+++ b/packages/mudtokens/src/erc721/ERC721Proxy.sol
@@ -12,7 +12,7 @@ import { LibERC721 } from "./LibERC721.sol";
 import { SystemRegistry } from "@latticexyz/world/src/modules/core/tables/SystemRegistry.sol";
 
 contract ERC721Proxy is IERC721Proxy {
-  IBaseWorld private world;
+  IBaseWorld public immutable world;
   bytes16 private immutable namespace;
 
   constructor(IBaseWorld _world, bytes16 _namespace) {

--- a/packages/mudtokens/src/erc721/LibERC721.sol
+++ b/packages/mudtokens/src/erc721/LibERC721.sol
@@ -16,7 +16,7 @@ import { IERC721Receiver } from "./interfaces/IERC721Receiver.sol";
 library LibERC721 {
   modifier onlyProxyWorld(bytes16 namespace) {
     ERC721Proxy _proxy = ERC721Proxy(proxy(namespace));
-    require(address(_proxy.world()) == StoreSwitch.getStoreAddress(), "ERC20: invalid world");
+    require(address(_proxy.world()) == StoreSwitch.getStoreAddress(), "ERC721: invalid world");
     _;
   }
 

--- a/packages/mudtokens/src/erc721/LibERC721.sol
+++ b/packages/mudtokens/src/erc721/LibERC721.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0;
 
 import { IBaseWorld } from "@latticexyz/world/src/interfaces/IBaseWorld.sol";
 import { ResourceSelector, ROOT_NAMESPACE } from "@latticexyz/world/src/ResourceSelector.sol";
+import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 import { BalanceTable, AllowanceTable, MetadataTable, ERC721Table} from "../codegen/Tables.sol";
 import { IERC165 } from "../common/IERC165.sol";
@@ -13,6 +14,12 @@ import { ERC721_METADATA_T as METADATA_T, ERC721_T, ERC721_BALANCE_T as BALANCE_
 import { IERC721Receiver } from "./interfaces/IERC721Receiver.sol";
 
 library LibERC721 {
+  modifier onlyProxyWorld(bytes16 namespace) {
+    ERC721Proxy _proxy = ERC721Proxy(proxy(namespace));
+    require(address(_proxy.world()) == StoreSwitch.getStoreAddress(), "ERC20: invalid world");
+    _;
+  }
+
   function getSelector(bytes16 namespace, bytes16 _name) private pure returns (bytes32) {
     return ResourceSelector.from(namespace, _name);
   }
@@ -428,27 +435,27 @@ library LibERC721 {
     BalanceTable.set(world, getSelector(namespace, BALANCE_T), account, balance + amount);
   }
 
-  function emitTransfer(bytes16 namespace, address from, address to, uint256 amount) internal {
+  function emitTransfer(bytes16 namespace, address from, address to, uint256 amount) internal onlyProxyWorld(namespace) {
     ERC721Proxy(proxy(namespace)).emitTransfer(from, to, amount);
   }
 
-  function emitTransfer(IBaseWorld world, bytes16 namespace, address from, address to, uint256 amount) internal {
+  function emitTransfer(IBaseWorld world, bytes16 namespace, address from, address to, uint256 amount) internal onlyProxyWorld(namespace) {
     ERC721Proxy(proxy(world, namespace)).emitTransfer(from, to, amount);
   }
 
-  function emitApproval(bytes16 namespace, address from, address to, uint256 amount) internal {
+  function emitApproval(bytes16 namespace, address from, address to, uint256 amount) internal onlyProxyWorld(namespace) {
     ERC721Proxy(proxy(namespace)).emitApproval(from, to, amount);
   }
 
-  function emitApproval(IBaseWorld world, bytes16 namespace, address from, address to, uint256 amount) internal {
+  function emitApproval(IBaseWorld world, bytes16 namespace, address from, address to, uint256 amount) internal onlyProxyWorld(namespace) {
     ERC721Proxy(proxy(world, namespace)).emitApproval(from, to, amount);
   }
 
-  function emitApprovalForAll(bytes16 namespace, address from, address to, bool approved) internal {
+  function emitApprovalForAll(bytes16 namespace, address from, address to, bool approved) internal onlyProxyWorld(namespace) {
     ERC721Proxy(proxy(namespace)).emitApprovalForAll(from, to, approved);
   }
 
-  function emitApprovalForAll(IBaseWorld world, bytes16 namespace, address from, address to, bool approved) internal {
+  function emitApprovalForAll(IBaseWorld world, bytes16 namespace, address from, address to, bool approved) internal onlyProxyWorld(namespace) {
     ERC721Proxy(proxy(world, namespace)).emitApprovalForAll(from, to, approved);
   }
 
@@ -878,27 +885,27 @@ library LibERC721 {
     BalanceTable.set(world, getSelector(ROOT_NAMESPACE, BALANCE_T), account, balance + amount);
   }
 
-  function emitTransfer(address from, address to, uint256 amount) internal {
+  function emitTransfer(address from, address to, uint256 amount) internal  onlyProxyWorld(ROOT_NAMESPACE){
     ERC721Proxy(proxy(ROOT_NAMESPACE)).emitTransfer(from, to, amount);
   }
 
-  function emitTransfer(IBaseWorld world, address from, address to, uint256 amount) internal {
+  function emitTransfer(IBaseWorld world, address from, address to, uint256 amount) internal onlyProxyWorld(ROOT_NAMESPACE) {
     ERC721Proxy(proxy(world, ROOT_NAMESPACE)).emitTransfer(from, to, amount);
   }
 
-  function emitApproval(address from, address to, uint256 amount) internal {
+  function emitApproval(address from, address to, uint256 amount) internal onlyProxyWorld(ROOT_NAMESPACE) {
     ERC721Proxy(proxy(ROOT_NAMESPACE)).emitApproval(from, to, amount);
   }
 
-  function emitApproval(IBaseWorld world, address from, address to, uint256 amount) internal {
+  function emitApproval(IBaseWorld world, address from, address to, uint256 amount) internal onlyProxyWorld(ROOT_NAMESPACE){
     ERC721Proxy(proxy(world, ROOT_NAMESPACE)).emitApproval(from, to, amount);
   }
 
-  function emitApprovalForAll(address from, address to, bool approved) internal {
+  function emitApprovalForAll(address from, address to, bool approved) internal  onlyProxyWorld(ROOT_NAMESPACE){
     ERC721Proxy(proxy(ROOT_NAMESPACE)).emitApprovalForAll(from, to, approved);
   }
 
-  function emitApprovalForAll(IBaseWorld world, address from, address to, bool approved) internal {
+  function emitApprovalForAll(IBaseWorld world, address from, address to, bool approved) internal onlyProxyWorld(ROOT_NAMESPACE){
     ERC721Proxy(proxy(world, ROOT_NAMESPACE)).emitApprovalForAll(from, to, approved);
   }
 }


### PR DESCRIPTION
Boffee pointed out that a spoofer could register a system contract to a secondary world and spoof proxy events.

This PR enforces that the world calling the proxy emit functions must be the same as the world registered to the proxy, preventing this attack.